### PR TITLE
Sort by Bolt and change default sort

### DIFF
--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -14,7 +14,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
  */
 public class SortCommandParser implements Parser<SortCommand> {
     private static final Set<String> VALID_FIELDS = new HashSet<>(Arrays.asList(
-            "email", "major", "name", "phone", "star"
+            "email", "major", "name", "phone", "star", "bolt"
     ));
     /**
      * Parses the given {@code String} of arguments in the context of the SortCommand

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -100,11 +100,13 @@ public class ModelManager implements Model {
 
     @Override
     public void deleteStudent(Student target) {
+        updateSortedStudentListByField("name", true);
         addressBook.removeStudent(target);
     }
 
     @Override
     public void addStudent(Student student) {
+        updateSortedStudentListByField("name", true);
         addressBook.addStudent(student);
         updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
     }
@@ -112,8 +114,8 @@ public class ModelManager implements Model {
     @Override
     public void setStudent(Student target, Student editedStudent) {
         requireAllNonNull(target, editedStudent);
-
         addressBook.setStudent(target, editedStudent);
+        updateSortedStudentListByField("name", true);
     }
 
     //=========== Filtered & Sorted Student List Accessors =============================================================
@@ -142,7 +144,7 @@ public class ModelManager implements Model {
         Comparator<Student> comparator;
         switch (field.toLowerCase()) {
         case "email":
-            comparator = Comparator.comparing(Student::getEmail);
+            comparator = Comparator.comparing(Student::getEmail).thenComparing(Student::getName);
             break;
         case "major":
             comparator = Comparator.comparing(Student::getMajor);
@@ -156,12 +158,16 @@ public class ModelManager implements Model {
         case "star":
             comparator = Comparator.comparing(Student::getStar);
             break;
+        case "bolt":
+            comparator = Comparator.comparing(Student::getBolt);
+            break;
         default:
             throw new IllegalArgumentException("Invalid field for sorting: " + field);
         }
         if (!isAscending) {
             comparator = comparator.reversed();
         }
+        comparator = comparator.thenComparing(Student::getName);
         sortedStudents.setComparator(comparator);
     }
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -144,7 +144,7 @@ public class ModelManager implements Model {
         Comparator<Student> comparator;
         switch (field.toLowerCase()) {
         case "email":
-            comparator = Comparator.comparing(Student::getEmail).thenComparing(Student::getName);
+            comparator = Comparator.comparing(Student::getEmail);
             break;
         case "major":
             comparator = Comparator.comparing(Student::getMajor);

--- a/src/main/java/seedu/address/model/student/Bolt.java
+++ b/src/main/java/seedu/address/model/student/Bolt.java
@@ -6,7 +6,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 /**
  * Represents a Student's bolts in the address book.
  */
-public class Bolt {
+public class Bolt implements Comparable<Bolt> {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Bolts given should be more than or equal to 0.";
@@ -51,6 +51,12 @@ public class Bolt {
 
         Bolt otherPhone = (Bolt) other;
         return numOfBolts.equals(otherPhone.numOfBolts);
+    }
+
+    @Override
+    public int compareTo(Bolt other) {
+        int otherStars = other.numOfBolts;
+        return this.numOfBolts.compareTo(otherStars);
     }
 
     @Override


### PR DESCRIPTION
Lets allow for sorting to work for bolt as well. lets also ensure that each time a student is added,removed or edited in classmonitor, the students displayed will default to sorted in ascending order of name. in the case of breaking ties after sorting, ascending order of names will also be used. fixes #72 