### PR TITLE
Add missing checks in find command parser

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -73,13 +73,17 @@ public class FindCommand extends Command {
             specificMessageUsage += "Finds students with stars that fall within the specified range.\n"
                     + "Parameters: OPERATOR NUMBER\n"
                     + "Example: " + COMMAND_WORD + " star < 1\n"
-                    + "Note: Valid operators are <, <=, >, >=, =. Only non-negative integers.";
+                    + "Note: Valid operators are <, <=, >, >=, =.\n"
+                    + "      Valid numbers are integers in range 0 to 50000.\n"
+                    + "      Invalid combinations are < 0 and > 50000 as they fall outside of the star range.";
             break;
         case "bolt":
             specificMessageUsage += "Finds students with bolts that fall within the specified range.\n"
                     + "Parameters: OPERATOR NUMBER\n"
                     + "Example: " + COMMAND_WORD + " bolt > 1\n"
-                    + "Note: Valid operators are <, <=, >, >=, =. Only non-negative integers.";
+                    + "Note: Valid operators are <, <=, >, >=, =.\n"
+                    + "      Valid numbers are integers in the range 0 to 50000.\n"
+                    + "      Invalid combinations are < 0 and > 50000 as they fall outside of the bolt range.";
             break;
         case "tag":
             specificMessageUsage += "Finds students with tags that contain the keyword specified.\n"

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -95,7 +95,9 @@ public class FindCommandParser implements Parser<FindCommand> {
             String sOperator = starArgs[0];
             Integer sOperand = Integer.parseInt(starArgs[1].trim());
 
-            if (isInvalidOperator(sOperator) || sOperand < 0) {
+            if (isInvalidOperator(sOperator)
+                    || sOperand < 0 || sOperand > 50000
+                    || isInvalidBound(sOperator, sOperand)) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                         FindCommand.getSpecificMessageUsage("star")));
             }
@@ -119,7 +121,9 @@ public class FindCommandParser implements Parser<FindCommand> {
             String bOperator = boltArgs[0];
             Integer bOperand = Integer.parseInt(boltArgs[1].trim());
 
-            if (isInvalidOperator(bOperator) || bOperand < 0) {
+            if (isInvalidOperator(bOperator)
+                    || bOperand < 0 || bOperand > 50000
+                    || isInvalidBound(bOperator, bOperand)) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                         FindCommand.getSpecificMessageUsage("bolt")));
             }
@@ -157,6 +161,18 @@ public class FindCommandParser implements Parser<FindCommand> {
                 && !operator.equals("<=")
                 && !operator.equals(">=")
                 && !operator.equals("=");
+    }
+
+    public boolean isInvalidBound(String operator, Integer operand) {
+        // Star and Bolt are at least 0 so < 0 is an invalid bound
+        if (operator.equals("<") && operand.equals(0)) {
+            return true;
+        }
+        // Star and Bolt are at most 50000 so > 50000 is an invalid bound
+        if (operator.equals(">") && operand.equals(50000)) {
+            return true;
+        }
+        return false;
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -150,7 +150,7 @@ public class FindCommandParser implements Parser<FindCommand> {
     }
 
     /**
-     * Checks if the operator is valid.
+     * Checks if the operator is invalid.
      *
      * @param operator
      * @return
@@ -163,6 +163,13 @@ public class FindCommandParser implements Parser<FindCommand> {
                 && !operator.equals("=");
     }
 
+    /**
+     * Checks if the operator and operand combination is invalid.
+     *
+     * @param operator
+     * @param operand
+     * @return
+     */
     public boolean isInvalidBound(String operator, Integer operand) {
         // Star and Bolt are at least 0 so < 0 is an invalid bound
         if (operator.equals("<") && operand.equals(0)) {

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -24,7 +24,11 @@ public class SortCommandParser implements Parser<SortCommand> {
     public SortCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
         String[] words = trimmedArgs.split("\\s+");
-        for (int i = 0; i < words.length; i++) { words[i] = words[i].toLowerCase(); }
+
+        for (int i = 0; i < words.length; i++) {
+            words[i] = words[i].toLowerCase();
+        }
+
         if (words.length != 2) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
         }


### PR DESCRIPTION
Let's update the find command parser to accurately reject invalid bounds. 

Fixes #118 #131 