### PR TITLE
Update find starbolt bound

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -101,9 +101,11 @@ public class FindCommandParser implements Parser<FindCommand> {
             }
 
             return new FindCommand(new StarWithinBoundsPredicate(sOperator, sOperand));
-        } catch (IndexOutOfBoundsException | NumberFormatException e) {
+        } catch (IndexOutOfBoundsException e) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     FindCommand.getSpecificMessageUsage("star")));
+        } catch (NumberFormatException e) {
+            throw new ParseException("Number should be an integer in range [0,  2147483647].");
         }
     }
 
@@ -125,9 +127,11 @@ public class FindCommandParser implements Parser<FindCommand> {
             }
 
             return new FindCommand(new BoltWithinBoundsPredicate(bOperator, bOperand));
-        } catch (IndexOutOfBoundsException | NumberFormatException e) {
+        } catch (IndexOutOfBoundsException e) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     FindCommand.getSpecificMessageUsage("bolt")));
+        } catch (NumberFormatException e) {
+            throw new ParseException("Number should be an integer in range [0, 2147483647].");
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -105,7 +105,7 @@ public class FindCommandParser implements Parser<FindCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     FindCommand.getSpecificMessageUsage("star")));
         } catch (NumberFormatException e) {
-            throw new ParseException("Number should be an integer in range [0,  2147483647].");
+            throw new ParseException("Number should be an integer in range [0, 2147483647].");
         }
     }
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -62,7 +62,7 @@ public class FindCommandParserTest {
 
         // invalid operand
         assertParseFailure(parser, "star < a",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.getSpecificMessageUsage("star")));
+                "Number should be an integer in range [0, 2147483647].");
         assertParseFailure(parser, "star = -1",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.getSpecificMessageUsage("star")));
 
@@ -83,7 +83,7 @@ public class FindCommandParserTest {
 
         //invalid operand
         assertParseFailure(parser, "bolt < a",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.getSpecificMessageUsage("bolt")));
+                "Number should be an integer in range [0, 2147483647].");
         assertParseFailure(parser, "bolt = -1",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.getSpecificMessageUsage("bolt")));
 


### PR DESCRIPTION
ClassMonitor incorrectly throws invalid command error for `find star/bolt <operator> large_integer`, where large_integer > Integer.MAX_VALUE. 

Let's handle these large integers and throw an appropriate error message. 